### PR TITLE
Added a note in the README about Python 3.9 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ it compatible with Zigbee networks.
     ```
    
 3. Configure and build:
+
+   Building requires at Python 3.9 or later.
+
     ```sh
     cmake -DSDK_PREFIX=$(pwd)/../tl_zigbee_sdk -DTOOLCHAIN_PREFIX=$(pwd)/../tc32 -B build .
     cmake --build build --target z03mmc.zigbee


### PR DESCRIPTION
If using Python 3.8 the build process fails as described in issue #56 

This just adds a single line note about the Python >= 3.9 requirement to the README